### PR TITLE
Fix Makefile so targets now depend on dir

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ MKDIR_P = mkdir -p
 OUT_DIR = ./build
 BIN_DIR = ./bin
 
-.PHONY: dir
+.PHONY: dir all clean
 
 all: dir sane
 


### PR DESCRIPTION
This means that the required directories will definitely be created
before the target is created.
