### PR TITLE
Force builtins to be executed by main process

### DIFF
--- a/sane.c
+++ b/sane.c
@@ -51,8 +51,7 @@ int sane_help(char **argv)
 
 int sane_exit(char **argv)
 {
-    exit(EXIT_SUCCESS);
-    /* kill(getppid(), SIGUSR1); */
+    kill(getpid(), SIGUSR1);
 
     return EXIT_SUCCESS;
 }


### PR DESCRIPTION
Builtin commands are now executed by main process, fixes issue #22.
