### PR TITLE
Fix lab build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,16 +15,16 @@ ${BIN_DIR}:
 	${MKDIR_P} ${BIN_DIR}
 
 sane: dir token.o command.o sane.o main.c
-	gcc ${OUT_DIR}/token.o ${OUT_DIR}/command.o ${OUT_DIR}/sane.o main.c -o ${BIN_DIR}/sane -std=c99
+	gcc ${OUT_DIR}/token.o ${OUT_DIR}/command.o ${OUT_DIR}/sane.o main.c -o ${BIN_DIR}/sane -std=gnu99
 
 sane.o: dir sane.c sane.h
-	gcc -c sane.c -std=c99 -o ${OUT_DIR}/sane.o
+	gcc -c sane.c -std=gnu99 -o ${OUT_DIR}/sane.o
 
 command.o: dir command.c command.h
-	gcc -c command.c -std=c99 -o ${OUT_DIR}/command.o
+	gcc -c command.c -std=gnu99 -o ${OUT_DIR}/command.o
 
 token.o: dir token.c token.h
-	gcc -c token.c -std=c99 -o ${OUT_DIR}/token.o
+	gcc -c token.c -std=gnu99 -o ${OUT_DIR}/token.o
 
 clean:
 	rm ${OUT_DIR}/*.o

--- a/main.c
+++ b/main.c
@@ -76,7 +76,7 @@ void setupUser1SignalHandler()
     act.sa_handler = sane_handleSiguser1;
     // Initialize mask to contain no signals - no signals are blocked during
     // the execution of the handler
-    act.sa_mask = 0;
+    sigemptyset(&(act.sa_mask));
 
     // Assign handler structure to SIGCHLD
     if (sigaction(SIGUSR1, &act, NULL) != 0) {


### PR DESCRIPTION
Fixed minor things preventing program from building on lab machines.
- Changed from using c99 standard to gnu99 standard.
- Using sigempty set to set empty mask instead of setting mask to 0.

Fixes issue #16.
